### PR TITLE
save state for when the calling activity is destroyed

### DIFF
--- a/src/android/NativeCameraLauncher.java
+++ b/src/android/NativeCameraLauncher.java
@@ -362,4 +362,34 @@ public class NativeCameraLauncher extends CordovaPlugin {
 
 		return cache.getAbsolutePath();
 	}
+
+	@Override
+	public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {
+		this.callbackContext = callbackContext;
+
+		this.mQuality = state.getInt("mQuality");
+		this.targetWidth = state.getInt("targetWidth");
+		this.targetHeight = state.getInt("targetHeight");
+
+		this.imageUri = state.getParcelable("imageUri");
+		this.photo = (File) state.getSerializable("photo");
+
+		this.date = state.getString("date");
+
+		super.onRestoreStateForActivityResult(state, callbackContext);
+	}
+
+	@Override
+	public Bundle onSaveInstanceState() {
+
+		Bundle state = new Bundle();
+		state.putInt("mQuality", mQuality);
+		state.putInt("targetWidth", targetWidth);
+		state.putInt("targetHeight", targetHeight);
+		state.putString("date", date);
+		state.putParcelable("imageUri", imageUri);
+		state.putSerializable("photo", photo);
+
+		return state;
+	}
 }


### PR DESCRIPTION
When camera activity is launched, the calling activity may be destroyed in conditions with low memory. This fix saves the state and sets the state when the activity is again in foreground or created